### PR TITLE
refactor: update server port and fix build configuration

### DIFF
--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -1,5 +1,5 @@
 import { withAccelerate } from "@prisma/extension-accelerate";
-import { PrismaClient } from "../../prisma/generated/client.js";
+import { PrismaClient } from "../../prisma/generated/client";
 
 const prisma = new PrismaClient().$extends(withAccelerate());
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -79,7 +79,7 @@ import { serve } from "@hono/node-server";
 serve(
   {
     fetch: app.fetch,
-    port: 3000,
+    port: 8000,
   },
   (info) => {
     console.log(`Server is running on http://localhost:${info.port}`);

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,9 +1,11 @@
-import posthog from "posthog-js";
 import { env } from "@/env";
+import posthog from "posthog-js";
 
-posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
+if (process.env.NODE_ENV === "production" && env.NEXT_PUBLIC_POSTHOG_KEY) {
+  posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
   api_host: "/ingest",
   ui_host: "https://eu.posthog.com",
   defaults: "2025-05-24",
   capture_exceptions: false,
 });
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
+onlyBuiltDependencies:
+  - '@prisma/client'
+  - '@prisma/engines'
+  - '@tailwindcss/oxide'
+  - core-js
+  - esbuild
+  - prisma
+  - sharp


### PR DESCRIPTION
Here's why these changes matter: - Change backend port to 8000 - Only run PostHog in production - Fix prisma import path - Configure pnpm workspace build dependencies